### PR TITLE
Conversion from Final_Time as input to Max_Timesteps --> closes #7

### DIFF
--- a/examples/Heated_Plate/Heated_Plate.ini
+++ b/examples/Heated_Plate/Heated_Plate.ini
@@ -21,7 +21,7 @@ Boundary_Attr_4=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=1.0
+Max_Timesteps=1000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Heated_Plate_preCICE/jots/Heated_Plate_preCICE.ini
+++ b/examples/Heated_Plate_preCICE/jots/Heated_Plate_preCICE.ini
@@ -25,7 +25,7 @@ Boundary_Attr_4=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=0.5
+Max_Timesteps=500
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Modal_Oscillation_Plate_preCICE/jots/Modal_Oscillation_Plate_preCICE.ini
+++ b/examples/Modal_Oscillation_Plate_preCICE/jots/Modal_Oscillation_Plate_preCICE.ini
@@ -25,7 +25,7 @@ Boundary_Attr_4=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.01
-Final_Time=4.0
+Max_Timesteps=400
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Quiescent_IC_HeatFlux/Quiescent_IC_HeatFlux.ini
+++ b/examples/Quiescent_IC_HeatFlux/Quiescent_IC_HeatFlux.ini
@@ -21,7 +21,7 @@ Boundary_Attr_4=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Explicit
 Delta_Time=1e-7
-Final_Time=0.5
+Max_Timesteps=5e6
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Quiescent_IC_Isothermal/Quiescent_IC_Isothermal.ini
+++ b/examples/Quiescent_IC_Isothermal/Quiescent_IC_Isothermal.ini
@@ -21,7 +21,7 @@ Boundary_Attr_4=Isothermal, 300
 [TimeIntegration]
 Time_Scheme=Euler_Explicit
 Delta_Time=1e-7
-Final_Time=0.5
+Max_Timesteps=5e6
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Reinert_B1/Reinert_B1.ini
+++ b/examples/Reinert_B1/Reinert_B1.ini
@@ -24,7 +24,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.01
-Final_Time=40.0
+Max_Timesteps=4000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Reinert_B2/Reinert_B2.ini
+++ b/examples/Reinert_B2/Reinert_B2.ini
@@ -24,7 +24,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.01
-Final_Time=4.0
+Max_Timesteps=4000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Reinert_B3/Reinert_B3.ini
+++ b/examples/Reinert_B3/Reinert_B3.ini
@@ -24,7 +24,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.01
-Final_Time=4.0
+Max_Timesteps=400
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Restarted_Sinusoidal_Isothermal_Heated_Bar/Initial_Sinusoidal_Isothermal_Heated_Bar.ini
+++ b/examples/Restarted_Sinusoidal_Isothermal_Heated_Bar/Initial_Sinusoidal_Isothermal_Heated_Bar.ini
@@ -21,7 +21,7 @@ Boundary_Attr_3=Sinusoidal_Isothermal, 5, 6.283185307, 0, 300
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=1.0
+Max_Timesteps=1000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Restarted_Sinusoidal_Isothermal_Heated_Bar/Restarted_Sinusoidal_Isothermal_Heated_Bar.ini
+++ b/examples/Restarted_Sinusoidal_Isothermal_Heated_Bar/Restarted_Sinusoidal_Isothermal_Heated_Bar.ini
@@ -18,7 +18,7 @@ Boundary_Attr_3=Sinusoidal_Isothermal, 5, 6.283185307, 0, 300
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=2.0
+Max_Timesteps=2000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Sinusoidal_HeatFlux_Heated_Bar/Sinusoidal_HeatFlux_Heated_Bar.ini
+++ b/examples/Sinusoidal_HeatFlux_Heated_Bar/Sinusoidal_HeatFlux_Heated_Bar.ini
@@ -20,7 +20,7 @@ Boundary_Attr_3=Sinusoidal_HeatFlux, 1100, 6.283185307, 0, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=2.0
+Max_Timesteps=2000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/examples/Sinusoidal_Isothermal_Heated_Bar/Sinusoidal_Isothermal_Heated_Bar.ini
+++ b/examples/Sinusoidal_Isothermal_Heated_Bar/Sinusoidal_Isothermal_Heated_Bar.ini
@@ -20,7 +20,7 @@ Boundary_Attr_3=Sinusoidal_Isothermal, 5, 6.283185307, 0, 300
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=2.0
+Max_Timesteps=2000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/src/conduction_operator.cpp
+++ b/src/conduction_operator.cpp
@@ -12,9 +12,8 @@ using namespace std;
  *
  *  Class ConductionOperator represents the right-hand side of the above ODE.
  */
-ConductionOperator::ConductionOperator(const Config& in_config, const BoundaryCondition* const* in_bcs, Array<int>* all_bdr_attr_markers, const MaterialProperty* rho_prop, const MaterialProperty* C_prop, const MaterialProperty* k_prop, ParFiniteElementSpace &f, double& t_ref, double& dt_ref, const double& tf_ref)
+ConductionOperator::ConductionOperator(const Config& in_config, const BoundaryCondition* const* in_bcs, Array<int>* all_bdr_attr_markers, const MaterialProperty* rho_prop, const MaterialProperty* C_prop, const MaterialProperty* k_prop, ParFiniteElementSpace &f, double& t_ref, double& dt_ref)
 :  TimeDependentOperator(f.GetTrueVSize(), t_ref),
-   tf(tf_ref),
    time(t_ref),
    dt(dt_ref), 
    rho_C(rho_prop->GetLocalValue(0), C_prop->GetCoeffRef()),
@@ -281,11 +280,6 @@ void ConductionOperator::ImplicitSolve(const double dt,
 
    // Solve for du_dt
    impl_solver->Mult(rhs, du_dt);
-}
-
-bool ConductionOperator::IsNotComplete() const
-{
-   return !(time > tf || abs(time-tf) < TIME_TOLERANCE);
 }
 
 void ConductionOperator::Iterate(Vector& u)

--- a/src/conduction_operator.hpp
+++ b/src/conduction_operator.hpp
@@ -16,7 +16,6 @@ class ConductionOperator : public TimeDependentOperator, public JOTSIterator
 {
 protected:
 
-   const double& tf;
    double& time;
    double& dt;
 
@@ -67,7 +66,7 @@ protected:
 
 public:
    // Note: bdr attributes array cannot be constant. May move into BoundaryCondition class in future
-   ConductionOperator(const Config& in_config, const BoundaryCondition* const* in_bcs, mfem::Array<int>* all_bdr_attr_markers, const MaterialProperty* rho_prop, const MaterialProperty* C_prop, const MaterialProperty* k_prop, ParFiniteElementSpace &f, double& t_ref, double& dt_ref, const double& tf_ref);
+   ConductionOperator(const Config& in_config, const BoundaryCondition* const* in_bcs, mfem::Array<int>* all_bdr_attr_markers, const MaterialProperty* rho_prop, const MaterialProperty* C_prop, const MaterialProperty* k_prop, ParFiniteElementSpace &f, double& t_ref, double& dt_ref);
    
    //--------------------------------------------------------------------------------------
    // TimeDependentOperator Function implementations:

--- a/src/config_file.cpp
+++ b/src/config_file.cpp
@@ -115,14 +115,14 @@ void Config::ReadTimeInt()
         using_time_integration = false;
         time_scheme_label = "Euler_Implicit";
         dt = 0.1;
-        tf = 10.0;
+        max_timesteps = 100;
     }
     else
     {
         using_time_integration = true;
         time_scheme_label = property_tree.get("TimeIntegration.Time_Scheme", "Euler_Implicit");
         dt = property_tree.get("TimeIntegration.Delta_Time", 0.1);
-        tf = property_tree.get("TimeIntegration.Final_Time", 10.0);
+        max_timesteps = property_tree.get("TimeIntegration.Max_Timesteps", 100);
     }
 }
 

--- a/src/config_file.hpp
+++ b/src/config_file.hpp
@@ -42,8 +42,7 @@ class Config
         
         bool using_time_integration;
         std::string time_scheme_label;      /*!< \brief Time integration scheme to use */
-        double t0;                    /*!< \brief Starting time */
-        double tf;                    /*!< \brief Final time to run to */
+        int max_timesteps;             /*!< \brief Delta time, timestep */
         double dt;                    /*!< \brief Delta time, timestep */
 
         std::string solver_label;                /*!< \brief Linear system solver type */
@@ -145,9 +144,9 @@ class Config
 
         std::string GetTimeSchemeLabel() const { return time_scheme_label; };
 
-        double GetFinalTime() const { return tf; };
+        int GetMaxTimesteps() const { return max_timesteps; };
 
-        void SetFinalTime(double in_tf) { tf = in_tf; };
+        void SetMaxTimesteps(int in_max_timesteps) {  max_timesteps = in_max_timesteps; };
 
         double Getdt() const { return dt; };
 

--- a/src/jots_driver.hpp
+++ b/src/jots_driver.hpp
@@ -39,7 +39,7 @@ class JOTSDriver
         double precice_saved_time;
         double precice_saved_it_num;
         double dt;
-        double tf;
+        int max_timesteps;
 
         JOTSIterator* jots_iterator;
         mfem::Vector u;

--- a/src/jots_iterator.hpp
+++ b/src/jots_iterator.hpp
@@ -10,7 +10,6 @@ class JOTSIterator
     protected:
         static constexpr double TIME_TOLERANCE = 1e-14;
     public:
-        virtual bool IsNotComplete() const = 0;
         virtual void Iterate(mfem::Vector& u) = 0;
         virtual void ProcessMatPropUpdate(MATERIAL_PROPERTY mp) = 0;
         virtual void UpdateNeumann() = 0;

--- a/tests/Reinert_B1.ini
+++ b/tests/Reinert_B1.ini
@@ -24,7 +24,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=1e-4
-Final_Time=2.0
+Max_Timesteps=20000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/tests/Reinert_B1_preCICE.ini
+++ b/tests/Reinert_B1_preCICE.ini
@@ -28,7 +28,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.01
-Final_Time=4.0
+Max_Timesteps=400
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/tests/Reinert_B2.ini
+++ b/tests/Reinert_B2.ini
@@ -24,7 +24,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=1e-4
-Final_Time=2.0
+Max_Timesteps=20000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/tests/Reinert_B3.ini
+++ b/tests/Reinert_B3.ini
@@ -24,7 +24,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=1e-4
-Final_Time=2.0
+Max_Timesteps=20000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/tests/Reinert_B3_preCICE.ini
+++ b/tests/Reinert_B3_preCICE.ini
@@ -28,7 +28,7 @@ Boundary_Attr_6=HeatFlux, 0
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.01
-Final_Time=4.0
+Max_Timesteps=40000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/tests/Restart_Files.ini
+++ b/tests/Restart_Files.ini
@@ -21,7 +21,7 @@ Boundary_Attr_3=Sinusoidal_Isothermal, 5, 6.283185307, 0, 300
 [TimeIntegration]
 Time_Scheme=Euler_Implicit
 Delta_Time=0.001
-Final_Time=1.0
+Max_Timesteps=1000
 
 [LinearSolverSettings]
 Solver=FGMRES

--- a/tests/test_helper.hpp.in
+++ b/tests/test_helper.hpp.in
@@ -80,7 +80,7 @@ int Analytical_Reg_Test(string input_file, std::function<double(const Vector &, 
 
     // Define exact solution coefficient
     FunctionCoefficient u_exact(Analytical);
-    u_exact.SetTime(input.GetFinalTime());
+    u_exact.SetTime(input.GetMaxTimesteps()*input.Getdt());
 
     // Get the finite-element approximation solution
     double error = driver->GetOutputManager()->GetVectorPGF("Temperature")->ComputeL2Error(u_exact);

--- a/unsteady_config_template.ini
+++ b/unsteady_config_template.ini
@@ -47,8 +47,7 @@ Boundary_Attr_7=preCICE_HeatFlux, _INTERFACE_MESH_NAME_ , _DEFAULT_HEATFLUX_
 [TimeIntegration]
 Time_Scheme=Euler_Implicit ; or Euler_Explicit, RK4
 Delta_Time=1.0e-2
-Final_Time=0.5
-
+Max_Timesteps=50
 
 [LinearSolverSettings]
 Solver=FGMRES ; FGMRES, GMRES, CG


### PR DESCRIPTION
User now provides maximum number of timesteps instead of a final time to aid in closing out of the main solver loop without needing a tolerance to account for floating point errors.

Also, the Iteration::IsStillRunning() function was removed. Steady state solvers will need to ensure that inner iterations only done once and probably no Output section processed? Can update later on.